### PR TITLE
Add ability to define middleware order

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,11 +30,18 @@ module.exports = function (merapi) {
                 app.use(bodyParser.json(bodyParserOptions));
                 app.use(bodyParser.urlencoded({ extended: true }));
 
+                let isRoutesInMiddleware = true;
+                
                 for (let i = 0; i < middleware.length; i++) {
-                    app.use(yield getFn(middleware[i]));
+                    if (middleware[i] === 'routes') {
+                        app.use(yield router(injector, routes, routerOptions));
+                        isRoutesInMiddleware = !isRoutesInMiddleware;
+                    } else {
+                        app.use(yield getFn(middleware[i]));
+                    }
                 }
 
-                app.use(yield router(injector, routes, routerOptions));
+                if (!isRoutesInMiddleware) app.use(yield router(injector, routes, routerOptions));
 
                 app.start = function () {
                     app.listen(port, host);

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (merapi) {
                 app.use(bodyParser.json(bodyParserOptions));
                 app.use(bodyParser.urlencoded({ extended: true }));
 
-                let isRoutesInMiddleware = true;
+                let isRoutesInMiddleware = false;
                 
                 for (let i = 0; i < middleware.length; i++) {
                     if (middleware[i] === 'routes') {


### PR DESCRIPTION
Previously there is no way to define middleware order using this plugin. This PR will add ability to define routing and middleware order by including `routes` keyword in configuration file as follow :

```yaml
app: 
  routes: 
    'GET /status': 'com.getStatus' 
  
  middleware:
    - com.accessHandler
    - routes
    - com.errorHandler
```

This will resolve express app to use routing and middleware in this particular order :

```javascript
app.use(com.accessHandler)
app.use(routes)
app.use(com.errorHandler)
```
To support backward compatibility if user does not specify `routes` keyword in middleware, it will resolve `routes` after all middleware, just like the existing one. 

This PR maintain 100% code coverage. Run the test using `yarn test` or `yarn cover`.
