### PR TITLE
handle error middleware

### DIFF
--- a/lib/getfn.js
+++ b/lib/getfn.js
@@ -19,10 +19,17 @@ module.exports = function (merapi) {
 
         if (com && com[fnName]) {
             let func = Array.isArray(params) ? com[fnName].bind(com, ...params) : com[fnName].bind(com);
-            return function (req, res, next) {
-                req.args = Object.assign({}, req.params, req.args);
-                return func(req, res, next);
-            };
+            if (func.length === 4) {
+                return function (err, req, res, next) {
+                    req.args = Object.assign({}, req.params, req.args);
+                    return func(err, req, res, next);
+                };
+            } else {
+                return function (req, res, next) {
+                    req.args = Object.assign({}, req.params, req.args);
+                    return func(req, res, next);
+                };
+            }
         }
 
         throw new Error(`Cannot find function '${fnName}' of component '${comName}'`);


### PR DESCRIPTION
Ini saya menambahkan handler utk error middleware.
Karena saya mau mengimplementasikan `errorHandler`nya sentry terjadi error karena tidak ada handler error.
Jadi saya tambahkan pengecekan. jika `func.length === 4` return nya jadi `(err, req, res, next)`